### PR TITLE
Ensure Apps Script web app assets are valid

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -61,6 +61,20 @@ const SESSION_CACHE_SECONDS = 6 * 60 * 60;
 const PASSWORD_SALT = 'SpiralDG::v1';
 // End constants section / Fin de la sección de constantes
 
+function doGet(e) {
+  initializeEnvironment();
+  const action = e && e.parameter ? e.parameter.action : '';
+  if (action === 'manifest') {
+    return doGetManifest();
+  }
+  if (action === 'serviceworker') {
+    return doGetServiceWorker();
+  }
+  return HtmlService.createHtmlOutputFromFile('sidebar')
+    .setTitle('Spiral Development Group Portal');
+}
+// End web app entry point section / Fin de la sección del punto de entrada de la aplicación web
+
 function setupSheets() {
   const ss = SpreadsheetApp.getActive();
   ensureSheet(ss, SHEET_NAMES.users, USERS_HEADERS);
@@ -363,7 +377,11 @@ function deleteTask(taskId, token) {
   if (session.role === 'Staff' && String(assignedTo) !== String(session.id)) {
     throw new Error('Staff cannot delete this task / El personal no puede eliminar esta tarea');
   }
-  if (session.role === 'Manager' && String(assignedTo) !== String(session.id) && !toBoolean(sheet.getRange(rowIndex, 9).getValue())) {
+  if (
+    session.role === 'Manager' &&
+    String(assignedTo) !== String(session.id) &&
+    !toBoolean(sheet.getRange(rowIndex, 9).getValue())
+  ) {
     throw new Error('Managers can only delete communal tasks / Los gerentes solo pueden eliminar tareas comunales');
   }
   sheet.deleteRow(rowIndex);
@@ -503,6 +521,7 @@ function runDiagnostics(token) {
   if (token) {
     requireSession(token);
   }
+  initializeEnvironment();
   const results = [];
   const ss = SpreadsheetApp.getActive();
   const requiredSheets = [
@@ -719,16 +738,18 @@ function adminUserExists() {
   }
   return false;
 }
+// End admin verification section / Fin de la sección de verificación de administrador
+
 function doGetManifest() {
   return ContentService.createTextOutput(
-    HtmlService.createHtmlOutputFromFile("manifest").getContent()
+    HtmlService.createHtmlOutputFromFile('manifest').getContent()
   ).setMimeType(ContentService.MimeType.JSON);
 }
+// End manifest handler section / Fin de la sección del manejador del manifiesto
 
 function doGetServiceWorker() {
   return ContentService.createTextOutput(
-    HtmlService.createHtmlOutputFromFile("serviceworker").getContent()
+    HtmlService.createHtmlOutputFromFile('serviceworker').getContent()
   ).setMimeType(ContentService.MimeType.JAVASCRIPT);
 }
-
-// End admin verification section / Fin de la sección de verificación de administrador
+// End service worker handler section / Fin de la sección del manejador del service worker

--- a/manifest.html
+++ b/manifest.html
@@ -1,7 +1,7 @@
 {
   "name": "Spiral Development Group",
   "short_name": "SpiralDG",
-  "start_url": "/",
+  "start_url": "YOUR_DEPLOYMENT_URL",
   "display": "standalone",
   "theme_color": "#007bff",
   "background_color": "#ffffff",

--- a/serviceworker.html
+++ b/serviceworker.html
@@ -1,7 +1,8 @@
 const CACHE_NAME = 'spiraldg-cache-v1';
 const ASSETS_TO_CACHE = [
-  './sidebar.html',
-  './manifest.json',
+  '/',
+  '?action=manifest',
+  '?action=serviceworker',
   'https://i.imgur.com/mRLfOoI.png',
   'https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&display=swap',
   'https://fonts.googleapis.com/icon?family=Material+Icons+Outlined'
@@ -46,7 +47,7 @@ self.addEventListener('fetch', (event) => {
           caches.open(CACHE_NAME).then((cache) => cache.put(event.request, cloned));
           return response;
         })
-        .catch(() => caches.match('./sidebar.html'));
+        .catch(() => caches.match('/'));
     })
   );
 });

--- a/sidebar.html
+++ b/sidebar.html
@@ -1365,10 +1365,6 @@
           }
         });
       }
-      function doGet(e) {
-  return HtmlService.createHtmlOutputFromFile("sidebar")
-    .setTitle("Spiral Development Group Portal");
-}
 
       // End language application section / Fin de la sección de aplicación de idioma
 
@@ -1422,30 +1418,33 @@
         if (!value) return '—';
         const date = new Date(value);
         if (isNaN(date)) return value;
-        return date.toLocaleDateString(currentLanguage === 'es' ? 'es-ES' : 'en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+        return date.toLocaleDateString(
+          currentLanguage === 'es' ? 'es-ES' : 'en-US',
+          { year: 'numeric', month: 'short', day: 'numeric' }
+        );
       }
       // End date formatter section / Fin de la sección del formateador de fechas
 
       function formatTime(value) {
-  if (!value) return '—';
-  const date = new Date(value);
-  if (isNaN(date)) return value;
-  return date.toLocaleTimeString(
-    currentLanguage === 'es' ? 'es-ES' : 'en-US',
-    { hour: '2-digit', minute: '2-digit' }
-  );
-}
-// End time formatter section / Fin de la sección del formateador de horas
-</script>
+        if (!value) return '—';
+        const date = new Date(value);
+        if (isNaN(date)) return value;
+        return date.toLocaleTimeString(
+          currentLanguage === 'es' ? 'es-ES' : 'en-US',
+          { hour: '2-digit', minute: '2-digit' }
+        );
+      }
+      // End time formatter section / Fin de la sección del formateador de horas
+    </script>
 
-<script>
-  if ("serviceWorker" in navigator) {
-    navigator.serviceWorker
-      .register("?action=serviceworker")
-      .then(reg => console.log("✅ Service Worker registered:", reg))
-      .catch(err => console.error("❌ Service Worker failed:", err));
-  }
-</script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker
+          .register('?action=serviceworker')
+          .then((reg) => console.log('✅ Service Worker registered:', reg))
+          .catch((err) => console.error('❌ Service Worker failed:', err));
+      }
+    </script>
 </body>
 </html>
 <!-- End sidebar.html file / Fin del archivo sidebar.html -->


### PR DESCRIPTION
## Summary
- add a doGet entry point that serves the sidebar UI or routes to manifest and service worker handlers
- return manifest and service worker payloads with the proper MIME types and update service worker caching to use Apps Script query parameters
- clean up the sidebar language helpers, keep service worker registration inline, and point the manifest start_url at YOUR_DEPLOYMENT_URL

## Testing
- not run (Google Apps Script environment)

------
https://chatgpt.com/codex/tasks/task_e_68cc646a48208327acc3e46e2fb761a6