### PR TITLE
Reset login page to debug blank rendering

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -62,25 +62,18 @@ const PASSWORD_SALT = 'SpiralDG::v1';
 // End constants section / Fin de la sección de constantes
 
 function doGet(e) {
-  initializeEnvironment();
+  var page = e && e.parameter.page ? e.parameter.page : 'landing';
+  if (page === 'login') {
+    return HtmlService.createHtmlOutputFromFile('login');
+  } else if (page === 'sidebar') {
+    return HtmlService.createHtmlOutputFromFile('sidebar');
+  } else {
+    return HtmlService.createHtmlOutputFromFile('landing');
+  }
+}
 
-  var action = e && e.parameter && e.parameter.action ? e.parameter.action : '';
-  if (action === 'manifest') {
-    return doGetManifest();
-  }
-  if (action === 'serviceworker') {
-    return doGetServiceWorker();
-  }
-
-  var page = e && e.parameter && e.parameter.page ? e.parameter.page : 'landing';
-  switch (page) {
-    case 'login':
-      return HtmlService.createHtmlOutputFromFile('login');
-    case 'sidebar':
-      return HtmlService.createHtmlOutputFromFile('sidebar');
-    default:
-      return HtmlService.createHtmlOutputFromFile('landing');
-  }
+function testLogin() {
+  return HtmlService.createHtmlOutput("<h1 style='color:green'>Direct render works!</h1>");
 }
 // End web app entry point section / Fin de la sección del punto de entrada de la aplicación web
 

--- a/login.html
+++ b/login.html
@@ -1,108 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Login Debug</title>
-    <style>
-      * {
-        box-sizing: border-box;
-      }
-
-      body {
-        margin: 0;
-        padding: 48px 16px;
-        font-family: Arial, Helvetica, sans-serif;
-        background: #f4f6fb;
-        color: #1f2933;
-        display: flex;
-        align-items: flex-start;
-        justify-content: center;
-      }
-
-      main {
-        width: min(480px, 100%);
-        background: #ffffff;
-        border: 2px solid #4f46ef;
-        border-radius: 12px;
-        padding: 32px 28px;
-        box-shadow: 0 12px 24px rgba(79, 70, 239, 0.15);
-      }
-
-      h1 {
-        margin-top: 0;
-        font-size: 2rem;
-        text-align: center;
-        color: #4f46ef;
-      }
-
-      p {
-        font-size: 1rem;
-        text-align: center;
-        margin-bottom: 24px;
-      }
-
-      form {
-        display: grid;
-        gap: 16px;
-      }
-
-      input,
-      button {
-        font-size: 1rem;
-        padding: 12px 14px;
-      }
-
-      input {
-        border: 1px solid #c7c9d9;
-        border-radius: 8px;
-      }
-
-      button {
-        background: #4f46ef;
-        color: #ffffff;
-        border: none;
-        border-radius: 8px;
-        cursor: pointer;
-      }
-
-      button:hover {
-        background: #352ee6;
-      }
-
-      #debug-log {
-        margin-top: 24px;
-        padding: 16px;
-        border-radius: 8px;
-        background: #f2f3ff;
-        border: 1px solid #c7c9d9;
-        min-height: 60px;
-        white-space: pre-wrap;
-      }
-    </style>
-  </head>
-  <body>
-    <main>
-      <h1>Login Page Debug</h1>
-      <p>If you see this, login.html is loading.</p>
-      <form>
-        <input type="text" placeholder="Username" />
-        <input type="password" placeholder="Password" />
-        <button type="button" onclick="alert('Login clicked')">Login</button>
-      </form>
-      <div id="debug-log"></div>
-    </main>
-    <script>
-      (function () {
-        var debugLog = document.getElementById('debug-log');
-        if (debugLog) {
-          debugLog.textContent = 'Debug log ready.';
-        }
-      })();
-
-      window.onerror = function (msg, src, line, col, err) {
-        document.body.innerHTML += "<pre style='color:red'>Error: " + msg + '</pre>';
-      };
-    </script>
-  </body>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Login Debug</title>
+</head>
+<body>
+  <h1 style="color:blue;text-align:center;">Hello from login.html</h1>
+  <p style="text-align:center;">If you see this text, the file is rendering correctly.</p>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- replace login.html with a minimal debug view that shows clear text
- simplify doGet handler to return login.html when requested and add a testLogin helper for direct rendering verification

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc7fbd0e4c8327b1247b29273a97c6