### PR TITLE
Update login routing and add test

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -62,18 +62,22 @@ const PASSWORD_SALT = 'SpiralDG::v1';
 // End constants section / Fin de la sección de constantes
 
 function doGet(e) {
-  var page = e && e.parameter.page ? e.parameter.page : 'landing';
-  if (page === 'login') {
-    return HtmlService.createHtmlOutputFromFile('login');
-  } else if (page === 'sidebar') {
-    return HtmlService.createHtmlOutputFromFile('sidebar');
+  var page = e && e.parameter.page ? e.parameter.page : "landing";
+  if (page === "login") {
+    return HtmlService.createHtmlOutputFromFile("login")
+      .setTitle("Login Page");
+  } else if (page === "sidebar") {
+    return HtmlService.createHtmlOutputFromFile("sidebar")
+      .setTitle("Sidebar Page");
   } else {
-    return HtmlService.createHtmlOutputFromFile('landing');
+    return HtmlService.createHtmlOutputFromFile("landing")
+      .setTitle("Landing Page");
   }
 }
 
-function testLogin() {
-  return HtmlService.createHtmlOutput("<h1 style='color:green'>Direct render works!</h1>");
+function testLoginDirect() {
+  return HtmlService.createHtmlOutputFromFile("login")
+    .setTitle("Direct Login Test");
 }
 // End web app entry point section / Fin de la sección del punto de entrada de la aplicación web
 


### PR DESCRIPTION
## Summary
- update the web app entry point to serve landing, login, or sidebar pages with titles based on the requested page
- add a testLoginDirect helper to render the login page directly for deployment testing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc81f8dd448327af319b0729b44f7e